### PR TITLE
Ansible 2.8 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ addons:
 
 install:
   # Install ansible and dependencies
-  - if [ "$ANSIBLE_VERSION" = "latest" ]; then pip install ansible ansible-lint --upgrade; else pip install ansible=="$ANSIBLE_VERSION" ansible-lint=="3.5.1" --upgrade; fi
+  - if [ "$ANSIBLE_VERSION" = "latest" ]; then pip install ansible ansible-lint --upgrade; else pip install ansible=="$ANSIBLE_VERSION" ansible-lint=="$ANSIBLE_LINT_VERSION" --upgrade; fi
 
   # Check ansible version
   - ansible --version

--- a/README.md
+++ b/README.md
@@ -47,6 +47,13 @@ Optional regular expressions used to modify or filter the list of files to be co
 The `conga_files_strip` expression is removed from the files on the target host. This is useful if files were generated with an additional path components for organization (e.g. `apache`).
 The `conga_files_filter` expression is used to filter the list of files to be copied. Only files matching the expression are processed. This is useful if you don't want to copy all files at once or exclude some altogether.
 
+## Result facts
+
+    conga_files_changed
+
+This fact has the value `true` when the deployment of the conga file(s)
+resulted in a change.
+
 ## Dependencies
 
 This role depends on the [wcm_io_devops.conga_facts](https://github.com/wcm-io-devops/ansible-conga-facts) role for supplying the list of files and directories to copy.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,10 +2,11 @@
 # ensures that all conga directories exist and copies over all files that CONGA
 # has generated for that combination.
 
-- name: Setup files and directories lists.
+- name: Setup files, directories lists and result fact.
   set_fact:
     _conga_directories: "{{ conga_files_directories }}"
     _conga_files: "{{ conga_files_files }}"
+    conga_files_changed: false
 
 - name: Map list of files to their paths.
   set_fact:
@@ -36,3 +37,8 @@
   with_items: "{{ _conga_files }}"
   register: _conga_files_result
   notify: "{{ conga_files_handlers | default(omit) }}"
+
+- name: "Set 'conga_files_changed' to true when changed."
+  set_fact:
+    conga_files_changed: true
+  when: _conga_files_result.changed

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -38,7 +38,7 @@
   register: _conga_files_result
   notify: "{{ conga_files_handlers | default(omit) }}"
 
-- name: "Set 'conga_files_changed' to true when changed."
+- name: "Set 'conga_files_changed' to true when changed." # noqa 503
   set_fact:
     conga_files_changed: true
   when: _conga_files_result.changed

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,4 +34,5 @@
     group: "{{ conga_files_group | default(omit) }}"
     mode: "{{ conga_files_mode | default(omit) }}"
   with_items: "{{ _conga_files }}"
+  register: _conga_files_result
   notify: "{{ conga_files_handlers | default(omit) }}"


### PR DESCRIPTION
This PR introduces the result fact `conga_files_changed` which will have the value `true` or `false`, depending on the changed result of the conga files copy task.

The result will then be used by the role [wcm_io_devops.conga_aem_cms](https://github.com/wcm-io-devops/ansible-conga-aem-cms) to determine if a restart is required or not.